### PR TITLE
Try to add 'break-quoted-field-on-newline'

### DIFF
--- a/test/test_delimited.py
+++ b/test/test_delimited.py
@@ -270,6 +270,12 @@ d,e",f
 g,h,i
 '''
 
+        quoted_5 = b'''a,b,c
+\\"d,"e"\\",f"""
+g,h,i
+'''
+
+
         fields = [{'name': 'str1', 'datatype': 'string'},
                   {'name': 'str2', 'datatype': 'string'},
                   {'name': 'str3', 'datatype': 'string'},]
@@ -279,9 +285,11 @@ g,h,i
         expected_2 = ['a', 'b', 'c'], ['d,e', 'f'], ['g', 'h', 'i']
         expected_3 = ['a', 'b', 'c'], ['\\"d', 'e,f'], ['g', 'h', 'i']
         expected_4 = ['a', 'b', 'c'], ['d', 'e"', 'f'], ['g', 'h', 'i']
+        expected_5 = ['a', 'b', 'c'], ['\\"d', 'e\\"', 'f"""'], ['g', 'h', 'i']
 
-        inputs = quoted_0, quoted_1, quoted_2, quoted_3, quoted_4
-        outputs = expected_0, expected_1, expected_2, expected_3, expected_4
+        inputs = quoted_0, quoted_1, quoted_2, quoted_3, quoted_4, quoted_5
+        outputs = (expected_0, expected_1, expected_2, expected_3, expected_4,
+                   expected_5)
         test_file = 'tmp_test_reader.txt'
 
         for i, (inp, out) in enumerate(zip(inputs, outputs)):


### PR DESCRIPTION
Tried to implement the feature request from http://bugs.python.org/issue30034. It's a shame it was rejected, because it'd be so clean to detect and fix inside the reader.

There is a [pure Python implementation of _csv](https://github.com/pybee/ouroboros/blob/master/ouroboros/_csv.py) in [Ourobouros](https://github.com/pybee/ouroboros).

It's clear that whatever we can do from the outside should be happening on the reader: you sorta need to parse the line to match quotes, because position matters a lot (with quotes sometimes being a valid cell content!).

Since that is out of the question, here's a proposal: bail out on easy cases (there are no quotes in the line, or all quotes are escaped, or all quotes are in valid positions like right before a delimiter) and when we'd need parsing anyway, create a reader and feed it just the current line. Then re-create the line from that and it *should* be semantically identical to fixing it ourselves.

Performance might be awful if you need a lot of fixing, should be OK if you have few lines with quotes. Custom parsing might be a big win if you have lots of lines with non-trivial valid quotes. I'd love to hear what you get on the large files mentioned in the b.p.o feature request.